### PR TITLE
Move config constants to dedicated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Para instalar todas las dependencias y ejecutar el servidor utiliza:
 
 El sistema invalida otras sesiones activas de un usuario cuando se inicia sesión
 en un nuevo dispositivo. Además, las sesiones expiran después de una hora. Este
-valor puede modificarse cambiando la constante `DURACION_SESION` en `app.py`.
+valor puede modificarse cambiando la constante `DURACION_SESION` en `app/config.py`.
 
 Si luego de actualizar obtienes un **Internal Server Error**, asegúrate de que
 la base de datos tenga la columna `session_token`. La aplicación intentará

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,8 @@ from email_utils import render_correo_html
 import base64
 import click
 
+from .config import *
+
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 load_dotenv(os.path.join(BASE_DIR, '.env'))
 
@@ -134,52 +136,6 @@ handler.setLevel(logging.INFO)
 app.logger.addHandler(handler)
 app.logger.setLevel(logging.INFO)
 
-TIEMPO_LIMITE_EDICION_REQUISICION = timedelta(minutes=30)
-DURACION_SESION = timedelta(hours=1)
-
-UNIDADES_DE_MEDIDA_SUGERENCIAS = [
-    'Kilogramo (Kg)', 'Gramo (g)', 'Miligramo (mg)', 'Tonelada (t)', 'Quintal (qq)', 'Libra (Lb)', 
-    'Saco (especificar peso)', 'Bulto (especificar peso)', 'Litro (L)', 'Mililitro (mL)', 
-    'Centímetro cúbico (cc ó cm³)', 'Metro cúbico (m³)', 'Galón (Gal)', 'Frasco (especificar volumen)', 
-    'Botella (especificar volumen)', 'Tambor (especificar volumen)', 'Barril (especificar volumen)', 'Pipa (agua)',
-    'Carretilla', 'Balde', 'Lata (especificar tamaño)', 'Metro (m)', 'Centímetro (cm)', 'Pulgada (in)', 
-    'Pie (ft)', 'Rollo (especificar longitud/tipo)', 'Metro cuadrado (m²)', 'Hectárea (Ha)',
-    'Unidad (Un)', 'Pieza (Pza)', 'Docena (Doc)', 'Ciento', 'Millar', 'Cabeza (Cbz) (ganado)', 
-    'Planta (Plt)', 'Semilla (por unidad o peso)', 'Mata', 'Atado', 'Fardo', 'Paca', 'Bala', 
-    'Caja (Cj)', 'Bolsa', 'Paleta', 'Hora (Hr)', 'Día', 'Semana', 'Mes', 'Jornal (trabajo)', 
-    'Ciclo (productivo)', 'Porcentaje (%)', 'Partes por millón (ppm)', 'mg/Kg', 'mg/L', 'g/Kg', 
-    'g/L', 'mL/L', 'cc/L', 'UI (Unidades Internacionales)', 'Dosis', 'Servicio (Serv)', 
-    'Global (Glb)', 'Lote', 'Viaje (transporte)', 'Aplicación', 'Otro (especificar)'
-]
-UNIDADES_DE_MEDIDA_SUGERENCIAS.sort()
-
-ESTADO_INICIAL_REQUISICION = 'Pendiente Revisión Almacén'
-ESTADOS_REQUISICION = [
-    (ESTADO_INICIAL_REQUISICION, 'Pendiente Revisión Almacén'),
-    ('Aprobada por Almacén', 'Aprobada por Almacén (Enviar a Compras)'),
-    ('Surtida desde Almacén', 'Surtida desde Almacén (Completada por Almacén)'),
-    ('Rechazada por Almacén', 'Rechazada por Almacén'),
-    ('Pendiente de Cotizar', 'Pendiente de Cotizar (En Compras)'),
-    ('Aprobada por Compras', 'Aprobada por Compras (Lista para Adquirir)'),
-    ('Rechazada por Compras', 'Rechazada por Compras'),
-    ('En Proceso de Compra', 'En Proceso de Compra'),
-    ('Comprada', 'Comprada (Esperando Recepción)'),
-    ('Recibida Parcialmente', 'Recibida Parcialmente (En Almacén)'),
-    ('Recibida Completa', 'Recibida Completa (En Almacén)'),
-    ('Cerrada', 'Cerrada (Proceso Finalizado)'),
-    ('Cancelada', 'Cancelada')
-]
-ESTADOS_REQUISICION_DICT = dict(ESTADOS_REQUISICION)
-
-ESTADOS_HISTORICOS = [
-    'Surtida desde Almacén',
-    'Rechazada por Almacén',
-    'Aprobada por Compras',
-    'Rechazada por Compras',
-    'Comprada',
-    'Cerrada',
-    'Cancelada'
-]
 
 from .forms import (
     LoginForm,

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,49 @@
+from datetime import timedelta
+
+TIEMPO_LIMITE_EDICION_REQUISICION = timedelta(minutes=30)
+DURACION_SESION = timedelta(hours=1)
+
+UNIDADES_DE_MEDIDA_SUGERENCIAS = [
+    'Kilogramo (Kg)', 'Gramo (g)', 'Miligramo (mg)', 'Tonelada (t)', 'Quintal (qq)', 'Libra (Lb)',
+    'Saco (especificar peso)', 'Bulto (especificar peso)', 'Litro (L)', 'Mililitro (mL)',
+    'Centímetro cúbico (cc ó cm³)', 'Metro cúbico (m³)', 'Galón (Gal)', 'Frasco (especificar volumen)',
+    'Botella (especificar volumen)', 'Tambor (especificar volumen)', 'Barril (especificar volumen)', 'Pipa (agua)',
+    'Carretilla', 'Balde', 'Lata (especificar tamaño)', 'Metro (m)', 'Centímetro (cm)', 'Pulgada (in)',
+    'Pie (ft)', 'Rollo (especificar longitud/tipo)', 'Metro cuadrado (m²)', 'Hectárea (Ha)',
+    'Unidad (Un)', 'Pieza (Pza)', 'Docena (Doc)', 'Ciento', 'Millar', 'Cabeza (Cbz) (ganado)',
+    'Planta (Plt)', 'Semilla (por unidad o peso)', 'Mata', 'Atado', 'Fardo', 'Paca', 'Bala',
+    'Caja (Cj)', 'Bolsa', 'Paleta', 'Hora (Hr)', 'Día', 'Semana', 'Mes', 'Jornal (trabajo)',
+    'Ciclo (productivo)', 'Porcentaje (%)', 'Partes por millón (ppm)', 'mg/Kg', 'mg/L', 'g/Kg',
+    'g/L', 'mL/L', 'cc/L', 'UI (Unidades Internacionales)', 'Dosis', 'Servicio (Serv)',
+    'Global (Glb)', 'Lote', 'Viaje (transporte)', 'Aplicación', 'Otro (especificar)'
+]
+UNIDADES_DE_MEDIDA_SUGERENCIAS.sort()
+
+ESTADO_INICIAL_REQUISICION = 'Pendiente Revisión Almacén'
+ESTADOS_REQUISICION = [
+    (ESTADO_INICIAL_REQUISICION, 'Pendiente Revisión Almacén'),
+    ('Aprobada por Almacén', 'Aprobada por Almacén (Enviar a Compras)'),
+    ('Surtida desde Almacén', 'Surtida desde Almacén (Completada por Almacén)'),
+    ('Rechazada por Almacén', 'Rechazada por Almacén'),
+    ('Pendiente de Cotizar', 'Pendiente de Cotizar (En Compras)'),
+    ('Aprobada por Compras', 'Aprobada por Compras (Lista para Adquirir)'),
+    ('Rechazada por Compras', 'Rechazada por Compras'),
+    ('En Proceso de Compra', 'En Proceso de Compra'),
+    ('Comprada', 'Comprada (Esperando Recepción)'),
+    ('Recibida Parcialmente', 'Recibida Parcialmente (En Almacén)'),
+    ('Recibida Completa', 'Recibida Completa (En Almacén)'),
+    ('Cerrada', 'Cerrada (Proceso Finalizado)'),
+    ('Cancelada', 'Cancelada')
+]
+ESTADOS_REQUISICION_DICT = dict(ESTADOS_REQUISICION)
+
+ESTADOS_HISTORICOS = [
+    'Surtida desde Almacén',
+    'Rechazada por Almacén',
+    'Aprobada por Compras',
+    'Rechazada por Compras',
+    'Comprada',
+    'Cerrada',
+    'Cancelada'
+]
+

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,8 @@ from datetime import datetime
 import pytz
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
-from . import db, ESTADO_INICIAL_REQUISICION
+from . import db
+from .config import ESTADO_INICIAL_REQUISICION
 
 class Rol(db.Model):
     __tablename__ = 'rol'


### PR DESCRIPTION
## Summary
- extract configuration constants to `app/config.py`
- import config constants in `app/__init__.py`
- adjust `app/models.py` to import from the new config module
- update documentation with the new constant path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_684de87201d08331b4628e59f279282f