### PR TITLE
Fix blueprint URLs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -91,7 +91,7 @@ def create_app():
     db.init_app(app)
     migrate.init_app(app, db)
     login_manager.init_app(app)
-    login_manager.login_view = 'login'
+    login_manager.login_view = 'main.login'
     login_manager.login_message = "Por favor, inicie sesión para acceder a esta página."
     login_manager.login_message_category = "info"
     csrf.init_app(app)
@@ -122,7 +122,7 @@ def validar_sesion_activa():
         if token_en_sesion != token_en_usuario:
             logout_user()
             flash('Tu sesión ha expirado o fue iniciada en otro dispositivo.', 'warning')
-            return redirect(url_for('login'))
+            return redirect(url_for('main.login'))
 
 
 # Filtro para convertir saltos de línea en etiquetas <br>

--- a/templates/500.html
+++ b/templates/500.html
@@ -3,5 +3,5 @@
 {% block content %}
 <h1 class="text-danger">Ocurrió un error</h1>
 <p>Lo sentimos, se produjo un error interno en el servidor.</p>
-<a href="{{ url_for('index') }}" class="btn btn-azul">Volver al inicio</a>
+<a href="{{ url_for('main.index') }}" class="btn btn-azul">Volver al inicio</a>
 {% endblock %}

--- a/templates/admin/confirmar_eliminar_usuario.html
+++ b/templates/admin/confirmar_eliminar_usuario.html
@@ -30,10 +30,10 @@
 </div>
 
 <div class="text-center mt-4">
-    <form method="POST" action="{{ url_for('eliminar_usuario_post', usuario_id=usuario.id) }}" class="d-inline-block fade-in">
+    <form method="POST" action="{{ url_for('main.eliminar_usuario_post', usuario_id=usuario.id) }}" class="d-inline-block fade-in">
         {{ form.hidden_tag() }}
         {{ form.submit(class="btn btn-danger") }}
     </form>
-    <a href="{{ url_for('editar_usuario', usuario_id=usuario.id) }}" class="btn btn-azul ml-2">Cancelar</a>
+    <a href="{{ url_for('main.editar_usuario', usuario_id=usuario.id) }}" class="btn btn-azul ml-2">Cancelar</a>
 </div>
 {% endblock %}

--- a/templates/admin/crear_usuario.html
+++ b/templates/admin/crear_usuario.html
@@ -5,7 +5,7 @@
 <div class="container mt-4">
     <h1 class="mb-4 page-title">Crear Nuevo Usuario</h1>
 
-    <form method="POST" action="{{ url_for('crear_usuario') }}" class="fade-in" novalidate>
+    <form method="POST" action="{{ url_for('main.crear_usuario') }}" class="fade-in" novalidate>
         {{ form.hidden_tag() }}
 
         <fieldset class="mb-3">
@@ -114,7 +114,7 @@
 
         <div class="form-group mt-4">
             {{ form.submit(class="btn btn-granja btn-lg") }}
-            <a href="{{ url_for('listar_usuarios') }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
+            <a href="{{ url_for('main.listar_usuarios') }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
         </div>
     </form>
 </div>

--- a/templates/admin/editar_usuario.html
+++ b/templates/admin/editar_usuario.html
@@ -5,7 +5,7 @@
 <div class="container mt-4">
     <h1 class="mb-4 page-title">Editar Usuario</h1>
 
-    <form method="POST" action="{{ url_for('editar_usuario', usuario_id=usuario_id) }}" class="fade-in" novalidate>
+    <form method="POST" action="{{ url_for('main.editar_usuario', usuario_id=usuario_id) }}" class="fade-in" novalidate>
         {{ form.hidden_tag() }}
 
         <fieldset class="mb-3">
@@ -105,9 +105,9 @@
 
         <div class="form-group mt-4">
             {{ form.submit(class="btn btn-granja btn-lg") }}
-            <a href="{{ url_for('listar_usuarios') }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
+            <a href="{{ url_for('main.listar_usuarios') }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
             {% if usuario_id != current_user.id %}
-            <a href="{{ url_for('confirmar_eliminar_usuario', usuario_id=usuario_id) }}" class="btn btn-danger btn-lg ml-2">Eliminar</a>
+            <a href="{{ url_for('main.confirmar_eliminar_usuario', usuario_id=usuario_id) }}" class="btn btn-danger btn-lg ml-2">Eliminar</a>
             {% endif %}
         </div>
     </form>

--- a/templates/admin/listar_usuarios.html
+++ b/templates/admin/listar_usuarios.html
@@ -5,7 +5,7 @@
 <div class="container mt-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h1 class="page-title mb-0">Gestión de Usuarios</h1>
-        <a href="{{ url_for('crear_usuario') }}" class="btn btn-granja">
+        <a href="{{ url_for('main.crear_usuario') }}" class="btn btn-granja">
             <i class="fas fa-plus-circle"></i> Crear Nuevo Usuario
         </a>
     </div>
@@ -41,7 +41,7 @@
                     </td>
                     <td>
                         {# Aquí podrías añadir botones para editar o cambiar estado de activación en el futuro #}
-                        <a href="{{ url_for('editar_usuario', usuario_id=usuario.id) }}" class="btn btn-sm btn-azul" title="Editar"><i class="fas fa-edit"></i></a>
+                        <a href="{{ url_for('main.editar_usuario', usuario_id=usuario.id) }}" class="btn btn-sm btn-azul" title="Editar"><i class="fas fa-edit"></i></a>
                     </td>
                 </tr>
                 {% endfor %}
@@ -54,21 +54,21 @@
     <nav aria-label="Paginación de usuarios">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if not usuarios_paginados.has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('listar_usuarios', page=usuarios_paginados.prev_num) if usuarios_paginados.has_prev else '#'}}">&laquo; Anterior</a>
+                <a class="page-link" href="{{ url_for('main.listar_usuarios', page=usuarios_paginados.prev_num) if usuarios_paginados.has_prev else '#'}}">&laquo; Anterior</a>
             </li>
             {% for page_num in usuarios_paginados.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                 {% if page_num %}
                     {% if usuarios_paginados.page == page_num %}
-                    <li class="page-item active"><a class="page-link" href="{{ url_for('listar_usuarios', page=page_num) }}">{{ page_num }}</a></li>
+                    <li class="page-item active"><a class="page-link" href="{{ url_for('main.listar_usuarios', page=page_num) }}">{{ page_num }}</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link" href="{{ url_for('listar_usuarios', page=page_num) }}">{{ page_num }}</a></li>
+                    <li class="page-item"><a class="page-link" href="{{ url_for('main.listar_usuarios', page=page_num) }}">{{ page_num }}</a></li>
                     {% endif %}
                 {% else %}
                     <li class="page-item disabled"><span class="page-link">...</span></li>
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if not usuarios_paginados.has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('listar_usuarios', page=usuarios_paginados.next_num) if usuarios_paginados.has_next else '#'}}">Siguiente &raquo;</a>
+                <a class="page-link" href="{{ url_for('main.listar_usuarios', page=usuarios_paginados.next_num) if usuarios_paginados.has_next else '#'}}">Siguiente &raquo;</a>
             </li>
         </ul>
     </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -138,7 +138,7 @@
 <body class="fade-in">
     <nav class="navbar navbar-expand-lg navbar-granja fixed-top">
         <div class="container">
-            <a class="navbar-brand" href="{{ url_for('index') }}">
+            <a class="navbar-brand" href="{{ url_for('main.index') }}">
                 <img src="{{ url_for('static', filename='images/logo_granja_mini.jpg') }}" alt="Logo Granja Los Molinos" class="logo-mini">
                 Granja Los Molinos
             </a>
@@ -152,25 +152,25 @@
                             <i class="fas fa-bars"></i> Menú
                         </a>
                         <div class="dropdown-menu" aria-labelledby="mainMenuDropdown">
-                            <a class="dropdown-item" href="{{ url_for('index') }}">
+                            <a class="dropdown-item" href="{{ url_for('main.index') }}">
                                 <i class="fas fa-home"></i> Inicio
                             </a>
                             {% if current_user.is_authenticated %}
-                                <a class="dropdown-item" href="{{ url_for('listar_requisiciones') }}">
+                                <a class="dropdown-item" href="{{ url_for('main.listar_requisiciones') }}">
                                     <i class="fas fa-tasks"></i> Ver Requisiciones Activas
                                 </a>
-                                <a class="dropdown-item" href="{{ url_for('historial_requisiciones') }}">
+                                <a class="dropdown-item" href="{{ url_for('main.historial_requisiciones') }}">
                                     <i class="fas fa-history"></i> Ver Historial
                                 </a>
-                                <a class="dropdown-item" href="{{ url_for('crear_requisicion') }}">
+                                <a class="dropdown-item" href="{{ url_for('main.crear_requisicion') }}">
                                     <i class="fas fa-plus-circle"></i> Crear Requisición
                                 </a>
                                 {% if current_user.rol_asignado and current_user.rol_asignado.nombre == 'Admin' %}
                                     <div class="dropdown-divider"></div>
-                                    <a class="dropdown-item" href="{{ url_for('listar_usuarios') }}">
+                                    <a class="dropdown-item" href="{{ url_for('main.listar_usuarios') }}">
                                         <i class="fas fa-users"></i> Gestionar Usuarios
                                     </a>
-                                    <a class="dropdown-item" href="{{ url_for('crear_usuario') }}">
+                                    <a class="dropdown-item" href="{{ url_for('main.crear_usuario') }}">
                                         <i class="fas fa-user-plus"></i> Crear Usuario
                                     </a>
                                 {% endif %}
@@ -190,14 +190,14 @@
                                 ({{ current_user.rol_asignado.nombre if current_user.rol_asignado else 'Sin Rol' }})
                             </a>
                             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userDropdownMenuLink">
-                                <a class="dropdown-item" href="{{ url_for('logout') }}">
+                                <a class="dropdown-item" href="{{ url_for('main.logout') }}">
                                     <i class="fas fa-sign-out-alt"></i> Cerrar Sesión
                                 </a>
                             </div>
                         </li>
                     {% else %}
                         <li class="nav-item {% if request.endpoint == 'login' %}active{% endif %}">
-                            <a class="nav-link" href="{{ url_for('login') }}">
+                            <a class="nav-link" href="{{ url_for('main.login') }}">
                                 <i class="fas fa-sign-in-alt"></i> Iniciar Sesión
                             </a>
                         </li>

--- a/templates/confirmar_eliminar_requisicion.html
+++ b/templates/confirmar_eliminar_requisicion.html
@@ -32,10 +32,10 @@
 </div>
 
 <div class="text-center mt-4">
-    <form method="POST" action="{{ url_for('eliminar_requisicion_post', requisicion_id=requisicion.id) }}" class="d-inline-block fade-in">
+    <form method="POST" action="{{ url_for('main.eliminar_requisicion_post', requisicion_id=requisicion.id) }}" class="d-inline-block fade-in">
         {{ form.hidden_tag() }}
         {{ form.submit(class="btn btn-danger") }}
     </form>
-    <a href="{{ url_for('ver_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-azul ml-2">Cancelar</a>
+    <a href="{{ url_for('main.ver_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-azul ml-2">Cancelar</a>
 </div>
 {% endblock %}

--- a/templates/crear_requisicion.html
+++ b/templates/crear_requisicion.html
@@ -135,7 +135,7 @@
             {% endif %}
         {% endwith %}
 
-        <form method="POST" action="{{ url_for('crear_requisicion') }}" class="fade-in" novalidate>
+        <form method="POST" action="{{ url_for('main.crear_requisicion') }}" class="fade-in" novalidate>
             {{ form.hidden_tag() }} 
 
             <fieldset>
@@ -240,7 +240,7 @@
             <button type="button" id="add-detalle" class="btn btn-azul mt-2 mb-3">Añadir Otro Ítem</button>
             <hr>
             {{ form.submit(class="btn btn-granja btn-lg") }}
-            <a href="{{ url_for('listar_requisiciones') }}" class="btn btn-azul btn-lg ml-2">
+            <a href="{{ url_for('main.listar_requisiciones') }}" class="btn btn-azul btn-lg ml-2">
                 <i class="fas fa-list"></i> Ver Requisiciones
             </a>
         </form>

--- a/templates/editar_requisicion.html
+++ b/templates/editar_requisicion.html
@@ -135,7 +135,7 @@
             {% endif %}
         {% endwith %}
 
-        <form method="POST" action="{{ url_for('editar_requisicion', requisicion_id=requisicion_id) }}" class="fade-in" novalidate>
+        <form method="POST" action="{{ url_for('main.editar_requisicion', requisicion_id=requisicion_id) }}" class="fade-in" novalidate>
             {{ form.hidden_tag() }} 
 
             <fieldset>
@@ -240,7 +240,7 @@
             <button type="button" id="add-detalle" class="btn btn-azul mt-2 mb-3">Añadir Otro Ítem</button>
             <hr>
             <input type="submit" value="Actualizar Requisición" class="btn btn-granja btn-lg">
-            <a href="{{ url_for('ver_requisicion', requisicion_id=requisicion_id) }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
+            <a href="{{ url_for('main.ver_requisicion', requisicion_id=requisicion_id) }}" class="btn btn-azul btn-lg ml-2">Cancelar</a>
         </form>
     </div>
 

--- a/templates/historial_requisiciones.html
+++ b/templates/historial_requisiciones.html
@@ -5,13 +5,13 @@
 {% block content %}
 <h1 class="page-title mb-0">{{ title }}</h1> {# El título será "Historial de Requisiciones" #}
 <div class="action-buttons">
-    <a href="{{ url_for('listar_requisiciones') }}" class="btn {% if vista_actual == 'activas' %}btn-azul{% else %}btn-granja{% endif %}">
+    <a href="{{ url_for('main.listar_requisiciones') }}" class="btn {% if vista_actual == 'activas' %}btn-azul{% else %}btn-granja{% endif %}">
         <i class="fas fa-tasks"></i> Ver Activas
     </a>
-    <a href="{{ url_for('historial_requisiciones') }}" class="btn {% if vista_actual == 'historial' %}btn-azul{% else %}btn-granja{% endif %}">
+    <a href="{{ url_for('main.historial_requisiciones') }}" class="btn {% if vista_actual == 'historial' %}btn-azul{% else %}btn-granja{% endif %}">
         <i class="fas fa-history"></i> Ver Historial
     </a>
-    <a href="{{ url_for('crear_requisicion') }}" class="btn btn-granja">
+    <a href="{{ url_for('main.crear_requisicion') }}" class="btn btn-granja">
         <i class="fas fa-plus-circle"></i> Crear Nueva Requisición
     </a>
 </div>
@@ -57,7 +57,7 @@
                     </td>
                     <td>{{ req.estado }}</td>
                     <td>
-                        <a href="{{ url_for('ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm action-icon" title="Ver Detalles">
+                        <a href="{{ url_for('main.ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm action-icon" title="Ver Detalles">
                             <i class="fas fa-eye"></i>
                         </a>
                     </td>
@@ -70,21 +70,21 @@
     <nav aria-label="Paginación de historial">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if not requisiciones_paginadas.has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('historial_requisiciones', page=requisiciones_paginadas.prev_num) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
+                <a class="page-link" href="{{ url_for('main.historial_requisiciones', page=requisiciones_paginadas.prev_num) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
             </li>
             {% for page_num in requisiciones_paginadas.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                 {% if page_num %}
                     {% if requisiciones_paginadas.page == page_num %}
-                    <li class="page-item active"><a class="page-link" href="{{ url_for('historial_requisiciones', page=page_num) }}">{{ page_num }}</a></li>
+                    <li class="page-item active"><a class="page-link" href="{{ url_for('main.historial_requisiciones', page=page_num) }}">{{ page_num }}</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link" href="{{ url_for('historial_requisiciones', page=page_num) }}">{{ page_num }}</a></li>
+                    <li class="page-item"><a class="page-link" href="{{ url_for('main.historial_requisiciones', page=page_num) }}">{{ page_num }}</a></li>
                     {% endif %}
                 {% else %}
                     <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if not requisiciones_paginadas.has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('historial_requisiciones', page=requisiciones_paginadas.next_num) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
+                <a class="page-link" href="{{ url_for('main.historial_requisiciones', page=requisiciones_paginadas.next_num) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
             </li>
         </ul>
     </nav>

--- a/templates/inicio.html
+++ b/templates/inicio.html
@@ -9,13 +9,13 @@
     <p class="lead">Selecciona una opción para continuar:</p>
 
     <div class="mt-5 d-flex justify-content-center flex-wrap">
-        <a href="{{ url_for('crear_requisicion') }}" class="btn btn-granja btn-lg m-2">
+        <a href="{{ url_for('main.crear_requisicion') }}" class="btn btn-granja btn-lg m-2">
             <i class="fas fa-plus-circle"></i> Crear Nueva Requisición
         </a>
-        <a href="{{ url_for('listar_requisiciones') }}" class="btn btn-azul btn-lg m-2">
+        <a href="{{ url_for('main.listar_requisiciones') }}" class="btn btn-azul btn-lg m-2">
             <i class="fas fa-tasks"></i> Ver Requisiciones Activas
         </a>
-        <a href="{{ url_for('historial_requisiciones') }}" class="btn btn-azul btn-lg m-2">
+        <a href="{{ url_for('main.historial_requisiciones') }}" class="btn btn-azul btn-lg m-2">
             <i class="fas fa-history"></i> Ver Historial
         </a>
     </div>

--- a/templates/listar_cotizadas.html
+++ b/templates/listar_cotizadas.html
@@ -18,7 +18,7 @@
         <td>{{ req.detalles[0].producto if req.detalles else '' }}</td>
         <td>{{ req.detalles[0].cantidad if req.detalles else '' }}</td>
         <td>
-          <a href="{{ url_for('ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm"><i class="fas fa-eye"></i></a>
+          <a href="{{ url_for('main.ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm"><i class="fas fa-eye"></i></a>
         </td>
       </tr>
       {% endfor %}

--- a/templates/listar_pendientes_cotizar.html
+++ b/templates/listar_pendientes_cotizar.html
@@ -18,9 +18,9 @@
         <td>{{ req.detalles[0].producto if req.detalles else '' }}</td>
         <td>{{ req.detalles[0].cantidad if req.detalles else '' }}</td>
         <td>
-          <a href="{{ url_for('ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm"><i class="fas fa-eye"></i></a>
+          <a href="{{ url_for('main.ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm"><i class="fas fa-eye"></i></a>
           {% if current_user.rol_asignado.nombre == 'Compras' %}
-            <a href="{{ url_for('editar_requisicion', requisicion_id=req.id) }}" class="btn btn-granja btn-sm"><i class="fas fa-edit"></i></a>
+            <a href="{{ url_for('main.editar_requisicion', requisicion_id=req.id) }}" class="btn btn-granja btn-sm"><i class="fas fa-edit"></i></a>
           {% endif %}
         </td>
       </tr>

--- a/templates/listar_por_estado.html
+++ b/templates/listar_por_estado.html
@@ -23,10 +23,10 @@
         <td>{{ req.detalles[0].producto if req.detalles else '' }}</td>
         <td>{{ req.detalles[0].cantidad if req.detalles else '' }}</td>
         <td>
-          <a href="{{ url_for('ver_requisicion', requisicion_id=req.id) }}"
+          <a href="{{ url_for('main.ver_requisicion', requisicion_id=req.id) }}"
              class="btn btn-azul btn-sm"><i class="fas fa-eye"></i></a>
           {% if current_user.rol_asignado.nombre == 'Compras' and estado == 'Pendiente de Cotizar' %}
-            <a href="{{ url_for('editar_requisicion', requisicion_id=req.id) }}"
+            <a href="{{ url_for('main.editar_requisicion', requisicion_id=req.id) }}"
                class="btn btn-granja btn-sm"><i class="fas fa-edit"></i></a>
           {% endif %}
         </td>
@@ -39,21 +39,21 @@
   <nav aria-label="Paginación por estado">
     <ul class="pagination justify-content-center">
       <li class="page-item {% if not requisiciones_paginadas.has_prev %}disabled{% endif %}">
-        <a class="page-link" href="{{ url_for('listar_por_estado', estado=estado, page=requisiciones_paginadas.prev_num) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
+        <a class="page-link" href="{{ url_for('main.listar_por_estado', estado=estado, page=requisiciones_paginadas.prev_num) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
       </li>
       {% for page_num in requisiciones_paginadas.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
         {% if page_num %}
           {% if requisiciones_paginadas.page == page_num %}
-          <li class="page-item active"><a class="page-link" href="{{ url_for('listar_por_estado', estado=estado, page=page_num) }}">{{ page_num }}</a></li>
+          <li class="page-item active"><a class="page-link" href="{{ url_for('main.listar_por_estado', estado=estado, page=page_num) }}">{{ page_num }}</a></li>
           {% else %}
-          <li class="page-item"><a class="page-link" href="{{ url_for('listar_por_estado', estado=estado, page=page_num) }}">{{ page_num }}</a></li>
+          <li class="page-item"><a class="page-link" href="{{ url_for('main.listar_por_estado', estado=estado, page=page_num) }}">{{ page_num }}</a></li>
           {% endif %}
         {% else %}
           <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
         {% endif %}
       {% endfor %}
       <li class="page-item {% if not requisiciones_paginadas.has_next %}disabled{% endif %}">
-        <a class="page-link" href="{{ url_for('listar_por_estado', estado=estado, page=requisiciones_paginadas.next_num) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
+        <a class="page-link" href="{{ url_for('main.listar_por_estado', estado=estado, page=requisiciones_paginadas.next_num) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
       </li>
     </ul>
   </nav>

--- a/templates/listar_requisiciones.html
+++ b/templates/listar_requisiciones.html
@@ -6,39 +6,39 @@
 
 <h1 class="page-title mb-0">{{ title }}</h1>
 <div class="action-buttons">
-    <a href="{{ url_for('listar_requisiciones') }}" class="btn {% if vista_actual == 'activas' %}btn-azul{% else %}btn-granja{% endif %}">
+    <a href="{{ url_for('main.listar_requisiciones') }}" class="btn {% if vista_actual == 'activas' %}btn-azul{% else %}btn-granja{% endif %}">
         <i class="fas fa-tasks"></i> Ver Activas
     </a>
-    <a href="{{ url_for('historial_requisiciones') }}" class="btn {% if vista_actual == 'historial' %}btn-azul{% else %}btn-granja{% endif %}">
+    <a href="{{ url_for('main.historial_requisiciones') }}" class="btn {% if vista_actual == 'historial' %}btn-azul{% else %}btn-granja{% endif %}">
         <i class="fas fa-history"></i> Ver Historial
     </a>
-    <a href="{{ url_for('crear_requisicion') }}" class="btn btn-granja">
+    <a href="{{ url_for('main.crear_requisicion') }}" class="btn btn-granja">
         <i class="fas fa-plus-circle"></i> Crear Nueva Requisición
     </a>
 </div>
 
 <!-- Botones de filtro para Requisiciones Pendientes -->
 <div class="filter-buttons mb-3" aria-label="Filtros">
-  <a href="{{ url_for('listar_requisiciones', filtro='todos') }}"
+  <a href="{{ url_for('main.listar_requisiciones', filtro='todos') }}"
      class="btn btn-azul {% if filtro=='todos' %}active{% endif %}">
     Todas
   </a>
 
   {% if current_user.rol_asignado.nombre == 'Almacen' %}
-    <a href="{{ url_for('listar_requisiciones', filtro='sin_revisar') }}"
+    <a href="{{ url_for('main.listar_requisiciones', filtro='sin_revisar') }}"
        class="btn btn-azul {% if filtro=='sin_revisar' %}active{% endif %}">
       Sin Revisar
     </a>
-    <a href="{{ url_for('listar_requisiciones', filtro='por_cotizar') }}"
+    <a href="{{ url_for('main.listar_requisiciones', filtro='por_cotizar') }}"
        class="btn btn-azul {% if filtro=='por_cotizar' %}active{% endif %}">
       Enviadas a Compra
     </a>
   {% elif current_user.rol_asignado.nombre == 'Compras' %}
-    <a href="{{ url_for('listar_requisiciones', filtro='recien_llegadas') }}"
+    <a href="{{ url_for('main.listar_requisiciones', filtro='recien_llegadas') }}"
        class="btn btn-azul {% if filtro=='recien_llegadas' %}active{% endif %}">
       Llegadas de Almacén
     </a>
-    <a href="{{ url_for('listar_requisiciones', filtro='por_cotizar') }}"
+    <a href="{{ url_for('main.listar_requisiciones', filtro='por_cotizar') }}"
        class="btn btn-azul {% if filtro=='por_cotizar' %}active{% endif %}">
       Pendientes por Cotizar
     </a>
@@ -87,7 +87,7 @@
                     <td>{{ req.estado }}</td>
                     <td>
                         <!-- Ver -->
-                        <a href="{{ url_for('ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm" title="Ver Detalles">
+                        <a href="{{ url_for('main.ver_requisicion', requisicion_id=req.id) }}" class="btn btn-azul btn-sm" title="Ver Detalles">
                             <i class="fas fa-eye"></i>
                         </a>
                         <!-- Editar -->
@@ -95,14 +95,14 @@
                         {% set fecha_creacion = req.fecha_creacion.replace(tzinfo=None) if req.fecha_creacion else None %}
                         {% set editable = fecha_creacion and (ahora <= fecha_creacion + TIEMPO_LIMITE_EDICION_REQUISICION) and req.creador_id == current_user.id %}
                         {% if editable or (current_user.rol_asignado and current_user.rol_asignado.nombre == 'Admin') %}
-                        <a href="{{ url_for('editar_requisicion', requisicion_id=req.id) }}" class="btn btn-granja btn-sm" title="Editar Requisición">
+                        <a href="{{ url_for('main.editar_requisicion', requisicion_id=req.id) }}" class="btn btn-granja btn-sm" title="Editar Requisición">
                             <i class="fas fa-pencil-alt"></i>
                         </a>
                         {% endif %}
                         <!-- Eliminar -->
                         {% set eliminable = fecha_creacion and (ahora <= fecha_creacion + TIEMPO_LIMITE_EDICION_REQUISICION) and req.creador_id == current_user.id %}
                         {% if eliminable or (current_user.rol_asignado and current_user.rol_asignado.nombre == 'Admin') %}
-                        <a href="{{ url_for('confirmar_eliminar_requisicion', requisicion_id=req.id) }}" class="btn btn-danger btn-sm" title="Eliminar Requisición">
+                        <a href="{{ url_for('main.confirmar_eliminar_requisicion', requisicion_id=req.id) }}" class="btn btn-danger btn-sm" title="Eliminar Requisición">
                             <i class="fas fa-trash-alt"></i>
                         </a>
                         {% endif %}
@@ -116,21 +116,21 @@
     <nav aria-label="Paginación de requisiciones">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if not requisiciones_paginadas.has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('listar_requisiciones', page=requisiciones_paginadas.prev_num, filtro=filtro) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
+                <a class="page-link" href="{{ url_for('main.listar_requisiciones', page=requisiciones_paginadas.prev_num, filtro=filtro) if requisiciones_paginadas.has_prev else '#'}}">&laquo; Anterior</a>
             </li>
             {% for page_num in requisiciones_paginadas.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
                 {% if page_num %}
                     {% if requisiciones_paginadas.page == page_num %}
-                    <li class="page-item active"><a class="page-link" href="{{ url_for('listar_requisiciones', page=page_num, filtro=filtro) }}">{{ page_num }}</a></li>
+                    <li class="page-item active"><a class="page-link" href="{{ url_for('main.listar_requisiciones', page=page_num, filtro=filtro) }}">{{ page_num }}</a></li>
                     {% else %}
-                    <li class="page-item"><a class="page-link" href="{{ url_for('listar_requisiciones', page=page_num, filtro=filtro) }}">{{ page_num }}</a></li>
+                    <li class="page-item"><a class="page-link" href="{{ url_for('main.listar_requisiciones', page=page_num, filtro=filtro) }}">{{ page_num }}</a></li>
                     {% endif %}
                 {% else %}
                     <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if not requisiciones_paginadas.has_next %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('listar_requisiciones', page=requisiciones_paginadas.next_num, filtro=filtro) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
+                <a class="page-link" href="{{ url_for('main.listar_requisiciones', page=requisiciones_paginadas.next_num, filtro=filtro) if requisiciones_paginadas.has_next else '#'}}">Siguiente &raquo;</a>
             </li>
         </ul>
     </nav>

--- a/templates/login.html
+++ b/templates/login.html
@@ -100,7 +100,7 @@
             {% endif %}
         {% endwith %}
 
-        <form method="POST" action="{{ url_for('login') }}{{ '?next=' ~ request.args.get('next', '') if request.args.get('next') else '' }}" class="fade-in" novalidate>
+        <form method="POST" action="{{ url_for('main.login') }}{{ '?next=' ~ request.args.get('next', '') if request.args.get('next') else '' }}" class="fade-in" novalidate>
             {{ form.hidden_tag() }}
             <div class="form-group">
                 <div class="input-group input-group-lg">

--- a/templates/requisicion_creada.html
+++ b/templates/requisicion_creada.html
@@ -11,7 +11,7 @@
     </a>
 </p>
 <p>
-    <a href="{{ url_for('listar_requisiciones') }}" class="btn btn-granja">
+    <a href="{{ url_for('main.listar_requisiciones') }}" class="btn btn-granja">
         <i class="fas fa-list"></i> Ir a Requisiciones
     </a>
 </p>

--- a/templates/ver_requisicion.html
+++ b/templates/ver_requisicion.html
@@ -6,11 +6,11 @@
 <h1 class="page-title">{{ title }}</h1>
 
 <div class="btn-actions mb-4">
-    <a href="{{ url_for('listar_requisiciones') }}" class="btn btn-azul">
+    <a href="{{ url_for('main.listar_requisiciones') }}" class="btn btn-azul">
         <i class="fas fa-arrow-left"></i> Ver Requisiciones Activas
     </a>
     {% if puede_editar %}
-        <a href="{{ url_for('editar_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-granja">
+        <a href="{{ url_for('main.editar_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-granja">
             <i class="fas fa-edit"></i> Editar Requisición
         </a>
     {% elif not editable_dentro_limite_original and not (current_user.rol_asignado and current_user.rol_asignado.nombre == 'Admin') %}
@@ -20,12 +20,12 @@
     {% endif %}
     
     {% if puede_eliminar %}
-    <a href="{{ url_for('confirmar_eliminar_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-danger">
+    <a href="{{ url_for('main.confirmar_eliminar_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-danger">
         <i class="fas fa-trash-alt"></i> Eliminar
     </a>
     {% endif %}
     {% if current_user.rol_asignado and current_user.rol_asignado.nombre in ['Compras', 'Admin'] %}
-    <a href="{{ url_for('imprimir_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-azul">
+    <a href="{{ url_for('main.imprimir_requisicion', requisicion_id=requisicion.id) }}" class="btn btn-azul">
         <i class="fas fa-print"></i> Imprimir PDF
     </a>
     {% endif %}
@@ -86,7 +86,7 @@
         {% if puede_cambiar_estado %}
         <hr>
         <h5 class="mt-3 mb-3">Cambiar Estado de la Requisición</h5>
-        <form method="POST" action="{{ url_for('ver_requisicion', requisicion_id=requisicion.id) }}" class="fade-in">
+        <form method="POST" action="{{ url_for('main.ver_requisicion', requisicion_id=requisicion.id) }}" class="fade-in">
             {{ form_estado.hidden_tag() }}
             <div class="form-row align-items-start">
                 <div class="form-group col-md-4">


### PR DESCRIPTION
## Summary
- set `login_manager.login_view` to use the `main` blueprint
- redirect to `main.login` after session expiry
- update routes and templates to reference URLs via `main.`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6851b0279a0c8331963b592f72d2f2da