### PR TITLE
Update blueprint route references

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -78,7 +78,7 @@ def login():
             flash("Inicio de sesión como Administrador exitoso.", "success")
             app.logger.info("Usuario 'admin' (virtual) ha iniciado sesión.")
             next_page = request.args.get("next")
-            return redirect(next_page or url_for("index"))
+            return redirect(next_page or url_for("main.index"))
 
         user = Usuario.query.filter_by(username=form.username.data).first()
         if user and user.check_password(form.password.data):

--- a/app/utils.py
+++ b/app/utils.py
@@ -40,7 +40,7 @@ def admin_required(f):
                 "Acceso no autorizado. Se requieren permisos de Administrador.",
                 "danger",
             )
-            return redirect(url_for("index"))
+            return redirect(url_for("main.index"))
         return f(*args, **kwargs)
 
     return decorated_function
@@ -51,7 +51,7 @@ def superadmin_required(f):
     def decorated_function(*args, **kwargs):
         if not current_user.is_authenticated or not current_user.superadmin:
             flash("Acceso restringido a superadministradores.", "danger")
-            return redirect(url_for("index"))
+            return redirect(url_for("main.index"))
         return f(*args, **kwargs)
 
     return decorated_function

--- a/templates/base.html
+++ b/templates/base.html
@@ -147,7 +147,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNavDropdown">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item dropdown {% if request.endpoint in ['index', 'listar_requisiciones', 'historial_requisiciones', 'crear_requisicion', 'listar_usuarios', 'crear_usuario'] %}active{% endif %}">
+                    <li class="nav-item dropdown {% if request.endpoint in ['main.index', 'main.listar_requisiciones', 'main.historial_requisiciones', 'main.crear_requisicion', 'main.listar_usuarios', 'main.crear_usuario'] %}active{% endif %}">
                         <a class="nav-link dropdown-toggle" href="#" id="mainMenuDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fas fa-bars"></i> Menú
                         </a>
@@ -196,7 +196,7 @@
                             </div>
                         </li>
                     {% else %}
-                        <li class="nav-item {% if request.endpoint == 'login' %}active{% endif %}">
+                        <li class="nav-item {% if request.endpoint == 'main.login' %}active{% endif %}">
                             <a class="nav-link" href="{{ url_for('main.login') }}">
                                 <i class="fas fa-sign-in-alt"></i> Iniciar Sesión
                             </a>


### PR DESCRIPTION
## Summary
- standardize `main.` blueprint route names in `app` helpers and templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6851b4f859388331a3c4ddb2f0727067