### PR TITLE
Update nginx config for gunicorn

### DIFF
--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -7,7 +7,7 @@ server {
     }
 
     location / {
-        proxy_pass http://localhost:8000;
+        proxy_pass http://unix:/home/gestion_compras/gunicorn.sock;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary
- configure nginx proxy to use gunicorn socket

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6851bb2b1ee483319de701c230fcacc3