### PR TITLE
Fix log handler path

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,7 +73,11 @@ def create_app():
     app = Flask(__name__, template_folder=os.path.join(BASE_DIR, 'templates'), static_folder=os.path.join(BASE_DIR, 'static'))
 
     if not app.debug:
-        handler = RotatingFileHandler('error.log', maxBytes=100000, backupCount=3)
+        handler = RotatingFileHandler(
+            os.path.join(BASE_DIR, 'logs', 'error.log'),
+            maxBytes=100000,
+            backupCount=3,
+        )
         handler.setLevel(logging.ERROR)
         app.logger.addHandler(handler)
 


### PR DESCRIPTION
## Summary
- configure the error log handler to store logs under `logs/error.log`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6851cd002adc83318506ddfc72f4ca8d