### PR TITLE
Refactor Rol imports and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ utilizando un dominio o una IP interna como `http://192.168.x.x/`.
 
 ```python
 from app import db, crear_datos_iniciales, app
+from app.models import Usuario, Rol, Departamento
 with app.app_context():
     db.create_all()
-   crear_datos_iniciales()
+    crear_datos_iniciales(Rol, Departamento, Usuario)
 ```
 
 ### Respaldos automáticos

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,16 +34,6 @@ db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
 csrf = CSRFProtect()
-from . import models
-from .models import (
-    Departamento,
-    Requisicion,
-    DetalleRequisicion,
-    ProductoCatalogo,
-    IntentoLoginFallido,
-    AuditoriaAcciones,
-    AdminVirtual,
-)
 from .utils import (
     ensure_session_token_column,
     ensure_ultimo_login_column,
@@ -173,7 +163,8 @@ if __name__ == '__main__':
     with app.app_context():
         db.create_all()
         try:
-            crear_datos_iniciales()
+            from .models import Rol, Usuario, Departamento
+            crear_datos_iniciales(Rol, Departamento, Usuario)
         except Exception as e:
             app.logger.warning(f"No se pudieron crear datos iniciales: {e}")
     # Ejecutar con `flask run` o gunicorn
@@ -182,7 +173,8 @@ if __name__ == '__main__':
 @app.cli.command('crear-datos')
 def cli_crear_datos():
     """Crea roles y departamentos iniciales."""
-    crear_datos_iniciales()
+    from .models import Rol, Usuario, Departamento
+    crear_datos_iniciales(Rol, Departamento, Usuario)
     click.echo('Datos iniciales creados.')
 
 
@@ -235,7 +227,8 @@ if __name__ == '__main__':
     with app.app_context():
         db.create_all()
         try:
-            crear_datos_iniciales()
+            from .models import Rol, Usuario, Departamento
+            crear_datos_iniciales(Rol, Departamento, Usuario)
         except Exception as e:
             app.logger.warning(f"No se pudieron crear datos iniciales: {e}")
     # Ejecutar con `flask run` o gunicorn

--- a/app/requisiciones/constants.py
+++ b/app/requisiciones/constants.py
@@ -45,3 +45,6 @@ ESTADOS_HISTORICOS = [
     'Cerrada',
     'Cancelada'
 ]
+
+# Alias conservado para compatibilidad con imports previos
+ESTADOS_HISTORICOS_REQUISICION = ESTADOS_HISTORICOS

--- a/app/routes.py
+++ b/app/routes.py
@@ -27,9 +27,6 @@ from .utils import (
 )
 
 from .models import (
-    Rol,
-    Usuario,
-    Departamento,
     # Requisicion, # Moved (mostly)
     # DetalleRequisicion, # Moved
     # ProductoCatalogo, # Moved
@@ -54,6 +51,8 @@ def login():
         return redirect(url_for('main.index'))
     form = LoginForm()
     ip_addr = request.remote_addr
+
+    from .models import Usuario
 
     if form.validate_on_submit():
         if exceso_intentos(ip_addr, form.username.data):
@@ -110,6 +109,8 @@ def logout():
 @login_required
 @admin_required
 def listar_usuarios():
+    from .models import Usuario
+
     page = request.args.get('page', 1, type=int)
     per_page = 10
     usuarios_paginados = db.session.query(Usuario).order_by(Usuario.username).paginate(page=page, per_page=per_page, error_out=False)
@@ -120,6 +121,7 @@ def listar_usuarios():
 @admin_required
 def crear_usuario():
     """Permite a un administrador crear nuevos usuarios."""
+    from .models import Rol, Usuario, Departamento
     form = UserForm()
     roles = Rol.query.all()
     departamentos = Departamento.query.all()
@@ -221,6 +223,8 @@ def crear_usuario():
 @login_required
 @admin_required
 def editar_usuario(usuario_id):
+    from .models import Usuario, Rol, Departamento
+
     usuario = Usuario.query.get_or_404(usuario_id)
     if usuario.superadmin and not current_user.superadmin:
         flash('No puede editar a un superadministrador.', 'danger')
@@ -294,6 +298,8 @@ def editar_usuario(usuario_id):
 @login_required
 @admin_required
 def confirmar_eliminar_usuario(usuario_id):
+    from .models import Usuario
+
     usuario = Usuario.query.get_or_404(usuario_id)
     if usuario.id == current_user.id:
         flash('No puede eliminar su propio usuario.', 'danger')
@@ -310,6 +316,8 @@ def confirmar_eliminar_usuario(usuario_id):
 @admin_required
 @superadmin_required
 def eliminar_usuario_post(usuario_id):
+    from .models import Usuario
+
     form = ConfirmarEliminarUsuarioForm()
     usuario = Usuario.query.get_or_404(usuario_id)
     if usuario.id == current_user.id:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 # Configurar password de administrador para pruebas
 os.environ.setdefault("ADMIN_PASSWORD", "admin123")
 
-from app import app as flask_app, db, crear_datos_iniciales, Usuario, Rol, Departamento, Requisicion
+from app import app as flask_app, db, crear_datos_iniciales
+from app.models import Usuario, Rol, Departamento, Requisicion
 
 
 def crear_usuario(username: str, rol_nombre: str, password: str = "test") -> Usuario:
@@ -38,7 +39,7 @@ def app():
     )
     with flask_app.app_context():
         db.create_all()
-        crear_datos_iniciales()
+        crear_datos_iniciales(Rol, Departamento, Usuario)
     yield flask_app
     with flask_app.app_context():
         db.session.remove()
@@ -55,7 +56,7 @@ def setup_db(app):
     """Crea y limpia la base de datos para cada prueba."""
     with app.app_context():
         db.create_all()
-        crear_datos_iniciales()
+        crear_datos_iniciales(Rol, Departamento, Usuario)
         yield
         db.session.remove()
         db.drop_all()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,7 +28,8 @@ def test_admin_can_change_user_password(client, setup_db, admin_user):
     # Login as admin
     client.post('/login', data={'username': 'admin', 'password': 'admin123'})
 
-    from app import db, Usuario, Rol, Departamento
+    from app import db
+    from app.models import Usuario, Rol, Departamento
 
     with client.application.app_context():
         rol = Rol.query.filter_by(nombre='Solicitante').first()

--- a/tests/test_flujo_requisiciones.py
+++ b/tests/test_flujo_requisiciones.py
@@ -3,7 +3,8 @@ from flask import url_for
 from uuid import uuid4
 from unittest.mock import call
 
-from app import app as flask_app, db, crear_datos_iniciales, Usuario, Rol, Departamento, Requisicion
+from app import app as flask_app, db, crear_datos_iniciales
+from app.models import Usuario, Rol, Departamento, Requisicion
 from app.requisiciones.constants import ESTADO_INICIAL_REQUISICION
 from app.utils import cambiar_estado_requisicion
 
@@ -16,7 +17,7 @@ def app(tmp_path):
     )
     with flask_app.app_context():
         db.create_all()
-        crear_datos_iniciales()
+        crear_datos_iniciales(Rol, Departamento, Usuario)
         yield flask_app
         db.session.remove()
         db.drop_all()
@@ -104,7 +105,7 @@ def test_aprobacion_por_almacen_envia_a_compras(app, mocker):
     almacen_user = crear_usuario('almacen_apr', 'Almacen')
     req = crear_requisicion_para(solicitante)
 
-    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user, None, Usuario, Rol)
     db.session.refresh(req)
     assert req.estado == 'Aprobada por Almacén'
 
@@ -126,7 +127,7 @@ def test_rechazo_por_almacen_envia_motivo(app, mocker):
     req = crear_requisicion_para(solicitante)
 
     cambiar_estado_requisicion(
-        req.id, 'Rechazada por Almacén', almacen_user, 'Falta stock'
+        req.id, 'Rechazada por Almacén', almacen_user, 'Falta stock', Usuario, Rol
     )
     assert enviar.call_count >= 1
     args = enviar.call_args[0]
@@ -141,9 +142,9 @@ def test_aprobacion_por_compras_envia_correo(app, mocker):
     almacen_user = crear_usuario('alm_apr_comp', 'Almacen')
     compras_act = crear_usuario('compras_act', 'Compras')
     req = crear_requisicion_para(solicitante)
-    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user, None, Usuario, Rol)
 
-    cambiar_estado_requisicion(req.id, 'Aprobada por Compras', compras_act)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Compras', compras_act, None, Usuario, Rol)
     db.session.refresh(req)
     assert req.estado == 'Aprobada por Compras'
     assert enviar.call_count >= 1
@@ -156,10 +157,10 @@ def test_pendiente_cotizar_envia_correo_a_compras(app, mocker):
     compras_user = crear_usuario('compraspc', 'Compras')
     almacen_user = crear_usuario('alm_pc', 'Almacen')
     req = crear_requisicion_para(solicitante)
-    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user, None, Usuario, Rol)
     enviar.reset_mock()
 
-    cambiar_estado_requisicion(req.id, 'Pendiente de Cotizar', compras_user)
+    cambiar_estado_requisicion(req.id, 'Pendiente de Cotizar', compras_user, None, Usuario, Rol)
     db.session.refresh(req)
     assert req.estado == 'Pendiente de Cotizar'
     assert enviar.call_count >= 1
@@ -173,10 +174,10 @@ def test_cambio_a_comprada_historial(app, client, mocker):
     compras_user = crear_usuario('comprador', 'Compras')
     almacen_user = crear_usuario('alm_hist', 'Almacen')
     req = crear_requisicion_para(solicitante)
-    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user)
-    cambiar_estado_requisicion(req.id, 'Aprobada por Compras', compras_user)
-    cambiar_estado_requisicion(req.id, 'En Proceso de Compra', compras_user)
-    cambiar_estado_requisicion(req.id, 'Comprada', compras_user)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen_user, None, Usuario, Rol)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Compras', compras_user, None, Usuario, Rol)
+    cambiar_estado_requisicion(req.id, 'En Proceso de Compra', compras_user, None, Usuario, Rol)
+    cambiar_estado_requisicion(req.id, 'Comprada', compras_user, None, Usuario, Rol)
 
     login(client, 'comprador')
     resp = client.get('/requisiciones/historial')
@@ -208,7 +209,7 @@ def test_visibilidad_requisiciones_por_rol(app, client):
     else:
         print("La requisición ya fue procesada por Almacén y es visible para Compras.")
 
-    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen)
+    cambiar_estado_requisicion(req.id, 'Aprobada por Almacén', almacen, None, Usuario, Rol)
     resp = client.get('/requisiciones')
     assert b'RQTEST' in resp.data
 

--- a/tests/test_limpiar.py
+++ b/tests/test_limpiar.py
@@ -1,7 +1,8 @@
 import pytz
 from datetime import datetime, timedelta
 
-from app import db, Requisicion, Usuario
+from app import db
+from app.models import Requisicion, Usuario
 from app import limpiar_requisiciones_viejas
 
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -4,7 +4,8 @@ from app import app, db, crear_datos_iniciales
 with app.app_context():
     db.create_all()
     try:
-        crear_datos_iniciales()
+        from app.models import Rol, Usuario, Departamento
+        crear_datos_iniciales(Rol, Departamento, Usuario)
     except Exception as exc:
         app.logger.warning(f"No se pudieron crear datos iniciales: {exc}")
 


### PR DESCRIPTION
## Summary
- load requisition constants from the requisiciones module
- avoid importing `Rol` in utils
- require passing models in helper calls
- update routes and tests for new signatures
- keep backwards compatibility with `ESTADOS_HISTORICOS_REQUISICION`
- remove top-level `Usuario` and `Departamento` imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68546236046c8331809cb7ab46a24ef9