### PR TITLE
Fix utils import path

### DIFF
--- a/app/requisiciones/routes.py
+++ b/app/requisiciones/routes.py
@@ -14,7 +14,7 @@ from .constants import (
     UNIDADES_DE_MEDIDA_SUGERENCIAS,
     TIEMPO_LIMITE_EDICION_REQUISICION
 )
-from ..utils import (
+from app.utils import (
     admin_required, # For limpiar_requisiciones_viejas_route
     agregar_producto_al_catalogo,
     obtener_sugerencias_productos,


### PR DESCRIPTION
## Summary
- use absolute import for utils in requisiciones routes
- verify utils.py does not import from requisiciones routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68599a5208a083318c53236ffec3ac90