### PR TITLE
Add comprehensive requisition tests

### DIFF
--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,0 +1,11 @@
+import pytest
+import sys
+
+if __name__ == "__main__":
+    # Ejecutar todas las pruebas en la carpeta tests y mostrar un resumen
+    result_code = pytest.main(["-q", "tests/"])
+    if result_code == 0:
+        print("Todas las pruebas pasaron exitosamente.")
+    else:
+        print("Algunas pruebas fallaron. Código de salida:", result_code)
+    sys.exit(result_code)

--- a/tests/test_limpiar.py
+++ b/tests/test_limpiar.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from app import db
 from app.models import Requisicion, Usuario
 from app import limpiar_requisiciones_viejas
+from app import generar_pdf_requisicion
 
 
 def crear_requisicion(usuario, estado, dias_ago, url=None):
@@ -23,6 +24,15 @@ def crear_requisicion(usuario, estado, dias_ago, url=None):
     db.session.add(req)
     db.session.commit()
     return req
+
+
+def test_generar_pdf_requisicion_genera_pdf_valido(app):
+    with app.app_context():
+        admin = Usuario.query.filter_by(username='admin').first()
+        req = crear_requisicion(admin, 'Pendiente de Revisión Almacén', 0)
+        pdf_bytes = generar_pdf_requisicion(req)
+        assert pdf_bytes[:4] == b'%PDF'
+        assert req.numero_requisicion.encode('latin-1') in pdf_bytes
 
 
 def test_limpiar_elimina_historicas_y_sube_pdf(app, mocker):

--- a/tests/test_permisos.py
+++ b/tests/test_permisos.py
@@ -1,0 +1,343 @@
+import pytest
+import pytz
+from datetime import datetime, timedelta
+
+from app import db
+from app.models import Usuario, Rol, Departamento, Requisicion, AuditoriaAcciones
+
+
+def crear_requisicion_prueba(usuario: Usuario, estado: str = None, dias_atras: int = 0) -> Requisicion:
+    """Crea y guarda en BD una requisición de prueba para el usuario dado."""
+    req = Requisicion(
+        numero_requisicion='RQTEST',
+        nombre_solicitante=usuario.nombre_completo,
+        cedula_solicitante=usuario.cedula,
+        correo_solicitante=usuario.email,
+        departamento_id=usuario.departamento_id or Departamento.query.first().id,
+        prioridad='Alta',
+        observaciones='Prueba',
+        creador_id=usuario.id,
+        estado=estado or 'Pendiente Revisión Almacén',
+    )
+    if dias_atras:
+        req.fecha_creacion = datetime.now(pytz.UTC) - timedelta(days=dias_atras)
+    db.session.add(req)
+    db.session.commit()
+    return req
+
+
+def test_solicitante_puede_editar_su_requisicion_en_30min(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_edit',
+            cedula='V11223344',
+            email='sol_edit@example.com',
+            nombre_completo='Sol Edit',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+        req = crear_requisicion_prueba(user)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_edit', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.get(f'/requisicion/{req_id}/editar')
+    assert resp.status_code == 200
+    assert b'RQTEST' in resp.data
+
+
+def test_solicitante_no_edita_despues_30min(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_edit2',
+            cedula='V44332211',
+            email='sol_edit2@example.com',
+            nombre_completo='Sol Edit2',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add(user)
+        db.session.commit()
+        req = crear_requisicion_prueba(user, dias_atras=1)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_edit2', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.get(f'/requisicion/{req_id}/editar', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'No tiene permiso para editar' in resp.data
+
+
+def test_solicitante_no_edita_despues_cambio_estado(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_edit3',
+            cedula='V55667788',
+            email='sol_edit3@example.com',
+            nombre_completo='Sol Edit3',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add(user)
+        db.session.commit()
+        req = crear_requisicion_prueba(user)
+        req.estado = 'Aprobada por Almacén'
+        db.session.commit()
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_edit3', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.get(f'/requisicion/{req_id}/editar', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'No tiene permiso para editar' in resp.data
+
+
+def test_otro_usuario_no_puede_editar_requisicion(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user1 = Usuario(
+            username='sol_owner',
+            cedula='V12121212',
+            email='owner@example.com',
+            nombre_completo='Owner User',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user1.set_password('pass123')
+        user2 = Usuario(
+            username='sol_other',
+            cedula='V34343434',
+            email='other@example.com',
+            nombre_completo='Other User',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user2.set_password('pass123')
+        db.session.add_all([user1, user2])
+        db.session.commit()
+        req = crear_requisicion_prueba(user1)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_other', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.get(f'/requisicion/{req_id}/editar', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'No tiene permiso para editar' in resp.data
+
+
+def test_admin_puede_editar_siempre(app, client):
+    with app.app_context():
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+        admin = Usuario(
+            username='admin_edit',
+            cedula='V90909090',
+            email='admin_edit@example.com',
+            nombre_completo='Admin Editor',
+            rol_id=rol_admin.id,
+            departamento_id=None,
+            activo=True,
+            superadmin=False,
+        )
+        admin.set_password('pass123')
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_time',
+            cedula='V78787878',
+            email='sol_time@example.com',
+            nombre_completo='Sol Time',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add_all([admin, user])
+        db.session.commit()
+        req = crear_requisicion_prueba(user, dias_atras=5)
+        req_id = req.id
+    client.post('/login', data={'username': 'admin_edit', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.get(f'/requisicion/{req_id}/editar')
+    assert resp.status_code == 200
+    assert b'RQTEST' in resp.data
+
+
+def test_solicitante_puede_eliminar_en_30min(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_del',
+            cedula='V56565656',
+            email='sol_del@example.com',
+            nombre_completo='Sol Delete',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add(user)
+        db.session.commit()
+        req = crear_requisicion_prueba(user)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_del', 'password': 'pass123'}, follow_redirects=True)
+    get_resp = client.get(f'/requisicion/{req_id}/confirmar_eliminar')
+    assert get_resp.status_code == 200
+    resp = client.post(f'/requisicion/{req_id}/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Requisicion.query.get(req_id) is None
+        log = AuditoriaAcciones.query.filter_by(modulo='Requisiciones', objeto='RQTEST', accion='eliminar').first()
+        assert log is not None
+        assert log.usuario_id == Usuario.query.filter_by(username='sol_del').first().id
+
+
+def test_solicitante_no_elimina_despues_30min(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_del2',
+            cedula='V56565657',
+            email='sol_del2@example.com',
+            nombre_completo='Sol Delete2',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add(user)
+        db.session.commit()
+        req = crear_requisicion_prueba(user)
+        req.fecha_creacion = datetime.now(pytz.UTC) - timedelta(days=1)
+        db.session.commit()
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_del2', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.post(f'/requisicion/{req_id}/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Requisicion.query.get(req_id) is not None
+        log = AuditoriaAcciones.query.filter_by(modulo='Requisiciones', objeto='RQTEST', accion='eliminar').first()
+        assert log is None
+
+
+def test_otro_usuario_no_puede_eliminar_requisicion(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        owner = Usuario(
+            username='sol_owner2',
+            cedula='V23232323',
+            email='owner2@example.com',
+            nombre_completo='Owner User2',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        owner.set_password('pass123')
+        other = Usuario(
+            username='sol_other2',
+            cedula='V45454545',
+            email='other2@example.com',
+            nombre_completo='Other User2',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        other.set_password('pass123')
+        db.session.add_all([owner, other])
+        db.session.commit()
+        req = crear_requisicion_prueba(owner)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_other2', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.post(f'/requisicion/{req_id}/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Requisicion.query.get(req_id) is not None
+        log = AuditoriaAcciones.query.filter_by(modulo='Requisiciones', objeto='RQTEST', accion='eliminar').first()
+        assert log is None
+
+
+def test_admin_puede_eliminar_cualquier_requisicion(app, client):
+    with app.app_context():
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+        admin = Usuario(
+            username='admin_del',
+            cedula='V97979797',
+            email='admindel@example.com',
+            nombre_completo='Admin Delete',
+            rol_id=rol_admin.id,
+            departamento_id=None,
+            activo=True,
+        )
+        admin.set_password('pass123')
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        user = Usuario(
+            username='sol_target',
+            cedula='V21212121',
+            email='targetreq@example.com',
+            nombre_completo='Target Req',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        user.set_password('pass123')
+        db.session.add_all([admin, user])
+        db.session.commit()
+        req = crear_requisicion_prueba(user)
+        req.fecha_creacion = datetime.now(pytz.UTC) - timedelta(days=10)
+        db.session.commit()
+        req_id = req.id
+    client.post('/login', data={'username': 'admin_del', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.post(f'/requisicion/{req_id}/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Requisicion.query.get(req_id) is None
+        log = AuditoriaAcciones.query.filter_by(modulo='Requisiciones', objeto='RQTEST', accion='eliminar').first()
+        assert log is not None
+        assert log.usuario_id == Usuario.query.filter_by(username='admin_del').first().id
+
+
+def test_no_permiso_cambio_estado_por_rol_incorrecto(app, client):
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        solicitante = Usuario(
+            username='sol_estado',
+            cedula='V66665555',
+            email='solestado@example.com',
+            nombre_completo='Sol Estado',
+            rol_id=rol_sol.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        solicitante.set_password('pass123')
+        rol_alm = Rol.query.filter_by(nombre='Almacen').first()
+        almacen = Usuario(
+            username='alm_estado',
+            cedula='V88880000',
+            email='almestado@example.com',
+            nombre_completo='Alm Estado',
+            rol_id=rol_alm.id,
+            departamento_id=Departamento.query.first().id,
+            activo=True,
+        )
+        almacen.set_password('pass123')
+        db.session.add_all([solicitante, almacen])
+        db.session.commit()
+        req = crear_requisicion_prueba(solicitante)
+        req_id = req.id
+    client.post('/login', data={'username': 'sol_estado', 'password': 'pass123'}, follow_redirects=True)
+    resp = client.post(f'/requisicion/{req_id}', data={'estado': 'Aprobada por Almacén', 'comentario_estado': ''}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'No tiene permiso para cambiar el estado' in resp.data or b'no valid' in resp.data.lower()
+    client.get('/logout')
+    client.post('/login', data={'username': 'alm_estado', 'password': 'pass123'}, follow_redirects=True)
+    resp2 = client.post(f'/requisicion/{req_id}', data={'estado': 'Aprobada por Almacén', 'comentario_estado': ''}, follow_redirects=True)
+    assert resp2.status_code == 200
+    with app.app_context():
+        req_db = Requisicion.query.get(req_id)
+        assert req_db.estado == 'Aprobada por Almacén'
+        log = AuditoriaAcciones.query.filter_by(modulo='Requisiciones', objeto=str(req_id), accion='estado:Aprobada por Almacén').first()
+        assert log is not None
+        assert log.usuario_id == Usuario.query.filter_by(username='alm_estado').first().id

--- a/tests/test_usuarios.py
+++ b/tests/test_usuarios.py
@@ -1,0 +1,251 @@
+import pytest
+
+from app import db
+from app.models import Usuario, Rol, AuditoriaAcciones
+
+
+def login_user(client, username: str, password: str):
+    """Helper to log in a user via the client and ensure success."""
+    resp = client.post('/login', data={'username': username, 'password': password}, follow_redirects=True)
+    assert resp.status_code == 200, f"Login failed for user {username}"
+    return resp
+
+
+def test_superadmin_can_create_any_user(app, client):
+    with app.app_context():
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+        superadmin_user = Usuario(
+            username='admin2',
+            cedula='V00000222',
+            email='admin2@example.com',
+            nombre_completo='Administrador2',
+            rol_id=rol_admin.id,
+            departamento_id=None,
+            activo=True,
+            superadmin=True,
+        )
+        superadmin_user.set_password('pass123')
+        db.session.add(superadmin_user)
+        db.session.commit()
+        superadmin_id = superadmin_user.id
+
+    login_user(client, 'admin2', 'pass123')
+    with app.app_context():
+        rol_superadmin = Rol.query.filter_by(nombre='Superadmin').first()
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+
+    new_data = {
+        'username': 'nuevo_super',
+        'cedula': 'V12345000',
+        'nombre_completo': 'Nuevo Superadmin',
+        'email': 'newsuper@example.com',
+        'password': 'abc123',
+        'confirm_password': 'abc123',
+        'rol_id': rol_superadmin.id,
+        'departamento_id': '0',
+        'activo': 'y',
+    }
+    response = client.post('/admin/usuarios/crear', data=new_data, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        nuevo_user = Usuario.query.filter_by(username='nuevo_super').first()
+        assert nuevo_user is not None
+        assert nuevo_user.rol_asignado.nombre == 'Superadmin'
+        assert nuevo_user.superadmin is True
+        log = AuditoriaAcciones.query.filter_by(modulo='Usuarios', objeto=nuevo_user.username, accion='crear').first()
+        assert log is not None
+        assert log.usuario_id == superadmin_id
+
+    new_data['username'] = 'nuevo_admin'
+    new_data['cedula'] = 'V12345001'
+    new_data['nombre_completo'] = 'Nuevo Admin'
+    new_data['email'] = 'newadmin@example.com'
+    new_data['rol_id'] = rol_admin.id
+    response = client.post('/admin/usuarios/crear', data=new_data, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        nuevo_user2 = Usuario.query.filter_by(username='nuevo_admin').first()
+        assert nuevo_user2 is not None
+        assert nuevo_user2.rol_asignado.nombre == 'Admin'
+        log2 = AuditoriaAcciones.query.filter_by(modulo='Usuarios', objeto=nuevo_user2.username, accion='crear').first()
+        assert log2 is not None and log2.usuario_id == superadmin_id
+
+
+def test_admin_can_create_only_allowed_roles(app, client):
+    with app.app_context():
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+        admin_user = Usuario(
+            username='admin_norm',
+            cedula='V00000333',
+            email='admin_norm@example.com',
+            nombre_completo='Admin Normal',
+            rol_id=rol_admin.id,
+            departamento_id=None,
+            activo=True,
+            superadmin=False,
+        )
+        admin_user.set_password('pass123')
+        db.session.add(admin_user)
+        db.session.commit()
+        admin_id = admin_user.id
+
+    login_user(client, 'admin_norm', 'pass123')
+    with app.app_context():
+        rol_almacen = Rol.query.filter_by(nombre='Almacen').first()
+        rol_compras = Rol.query.filter_by(nombre='Compras').first()
+
+    data_almacen = {
+        'username': 'user_almacen',
+        'cedula': 'V55555111',
+        'nombre_completo': 'User Almacen',
+        'email': 'almacen@example.com',
+        'password': 'test123',
+        'confirm_password': 'test123',
+        'rol_id': rol_almacen.id,
+        'departamento_id': '0',
+        'activo': 'y',
+    }
+    resp = client.post('/admin/usuarios/crear', data=data_almacen, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        u_almacen = Usuario.query.filter_by(username='user_almacen').first()
+        assert u_almacen is not None
+        assert u_almacen.rol_asignado.nombre == 'Almacen'
+        log = AuditoriaAcciones.query.filter_by(modulo='Usuarios', objeto=u_almacen.username, accion='crear').first()
+        assert log is not None and log.usuario_id == admin_id
+
+    data_compras = {
+        'username': 'user_compras',
+        'cedula': 'V55555112',
+        'nombre_completo': 'User Compras',
+        'email': 'compras@example.com',
+        'password': 'test123',
+        'confirm_password': 'test123',
+        'rol_id': rol_compras.id,
+        'departamento_id': '0',
+        'activo': 'y',
+    }
+    resp = client.post('/admin/usuarios/crear', data=data_compras, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        u_compras = Usuario.query.filter_by(username='user_compras').first()
+        assert u_compras is not None
+        assert u_compras.rol_asignado.nombre == 'Compras'
+        log2 = AuditoriaAcciones.query.filter_by(modulo='Usuarios', objeto=u_compras.username, accion='crear').first()
+        assert log2 is not None and log2.usuario_id == admin_id
+
+
+def test_admin_cannot_create_admin_or_superadmin(app, client):
+    login_user(client, 'admin_norm', 'pass123')
+    with app.app_context():
+        rol_admin = Rol.query.filter_by(nombre='Admin').first()
+        rol_super = Rol.query.filter_by(nombre='Superadmin').first()
+
+    data = {
+        'username': 'user_nope',
+        'cedula': 'V99999001',
+        'nombre_completo': 'User Nope',
+        'email': 'nope@example.com',
+        'password': 'test123',
+        'confirm_password': 'test123',
+        'rol_id': rol_admin.id,
+        'departamento_id': '0',
+        'activo': 'y',
+    }
+    resp = client.post('/admin/usuarios/crear', data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Usuario.query.filter_by(username='user_nope').first() is None
+        log = AuditoriaAcciones.query.filter_by(objeto='user_nope', accion='crear').first()
+        assert log is None
+
+    data['username'] = 'user_nope2'
+    data['cedula'] = 'V99999002'
+    data['email'] = 'nope2@example.com'
+    data['rol_id'] = rol_super.id
+    resp = client.post('/admin/usuarios/crear', data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Usuario.query.filter_by(username='user_nope2').first() is None
+        log2 = AuditoriaAcciones.query.filter_by(objeto='user_nope2', accion='crear').first()
+        assert log2 is None
+
+
+def test_admin_cannot_edit_superadmin(app, client):
+    with app.app_context():
+        rol_super = Rol.query.filter_by(nombre='Superadmin').first()
+        target_user = Usuario(
+            username='super_target',
+            cedula='V10101010',
+            email='target@example.com',
+            nombre_completo='Super Target',
+            rol_id=rol_super.id,
+            departamento_id=None,
+            activo=True,
+            superadmin=True,
+        )
+        target_user.set_password('pass123')
+        db.session.add(target_user)
+        db.session.commit()
+        target_id = target_user.id
+
+    login_user(client, 'admin_norm', 'pass123')
+    resp = client.post(
+        f'/admin/usuarios/{target_id}/editar',
+        data={
+            'username': 'super_target',
+            'cedula': 'V10101010',
+            'nombre_completo': 'Super Target Mod',
+            'email': 'target@example.com',
+            'rol_id': str(rol_super.id),
+            'departamento_id': '0',
+            'activo': 'y',
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    with app.app_context():
+        same_user = Usuario.query.get(target_id)
+        assert same_user is not None
+        assert same_user.nombre_completo == 'Super Target'
+        log = AuditoriaAcciones.query.filter_by(objeto=same_user.username, accion='editar').first()
+        assert log is None
+
+
+def test_admin_cannot_delete_superadmin(app, client):
+    login_user(client, 'admin_norm', 'pass123')
+    resp = client.post('/admin/usuarios/super_target/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Usuario.query.filter_by(username='super_target').first() is not None
+        log = AuditoriaAcciones.query.filter_by(objeto='super_target', accion='eliminar').first()
+        assert log is None
+
+
+def test_superadmin_can_delete_user(app, client):
+    login_user(client, 'admin2', 'pass123')
+    with app.app_context():
+        rol_sol = Rol.query.filter_by(nombre='Solicitante').first()
+        temp_user = Usuario(
+            username='temp_del',
+            cedula='V77777888',
+            email='tempdel@example.com',
+            nombre_completo='Temp Delete',
+            rol_id=rol_sol.id,
+            departamento_id=None,
+            activo=True,
+        )
+        temp_user.set_password('temp123')
+        db.session.add(temp_user)
+        db.session.commit()
+        temp_id = temp_user.id
+
+    get_resp = client.get(f'/admin/usuarios/{temp_id}/confirmar_eliminar')
+    assert get_resp.status_code == 200
+    resp = client.post(f'/admin/usuarios/{temp_id}/eliminar', data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert Usuario.query.get(temp_id) is None
+        log = AuditoriaAcciones.query.filter_by(modulo='Usuarios', objeto='temp_del', accion='eliminar').first()
+        assert log is not None
+        assert log.usuario_id == Usuario.query.filter_by(username='admin2').first().id


### PR DESCRIPTION
## Summary
- extend email flow tests with stricter assertions
- add new user and permission test suites
- expand cleaning tests with PDF validation
- provide run_all_tests.py helper script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685b0dc3e3848331bdecbc89ccd8b860