### PR TITLE
Add automatic JSON retry in solicitar_archivos

### DIFF
--- a/automatizador_codex.py
+++ b/automatizador_codex.py
@@ -102,13 +102,34 @@ def solicitar_archivos(lista_archivos: list[str], prompt: str, api_key: str):
         },
         {"role": "user", "content": prompt},
     ]
-    texto = generar_respuesta_modelo(mensajes, api_key)
-    datos = extraer_json(texto)
+
+    intentos = 0
+    texto = ""
+    datos = None
+
+    while intentos < 3:
+        texto = generar_respuesta_modelo(mensajes, api_key)
+        datos = extraer_json(texto)
+        if datos is not None:
+            break
+
+        intentos += 1
+        if intentos >= 3:
+            break
+        print("Respuesta no válida al solicitar archivos. Reintentando...")
+        mensajes.append(
+            {
+                "role": "user",
+                "content": "Por favor, responde únicamente con JSON válido.",
+            }
+        )
+
     if datos is None:
-        print("Respuesta no válida al solicitar archivos:")
+        print("No se pudo obtener un JSON válido al solicitar archivos:")
         print(texto)
     else:
         print("Archivos solicitados:", datos)
+
     return datos
 
 


### PR DESCRIPTION
## Summary
- improve `solicitar_archivos` to retry up to three times when the model does not return valid JSON

## Testing
- `python -m py_compile automatizador_codex.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685b67f0e6988331867e01151e2c8572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when requesting file lists by adding a retry mechanism for invalid responses.
	- Updated error messaging for clearer feedback when valid JSON cannot be obtained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->