### PR TITLE
Implement new error recovery logic in supervisor

### DIFF
--- a/supervisor_codex.py
+++ b/supervisor_codex.py
@@ -43,10 +43,27 @@ def main():
         if codigo == 0:
             break
         if intentos >= MAX_INTENTOS:
-            log("❌ Se alcanzó el máximo de reintentos.")
             break
         reintentar_fix(salida)
         intentos += 1
+
+    # Nueva lógica automática
+    if intentos >= MAX_INTENTOS:
+        log("❌ Se alcanzó el máximo de reintentos.")
+
+        if (
+            "Se alcanzó el máximo de reintentos" in salida
+            or "ImportError" in salida
+            or "cannot import name" in salida
+        ):
+            log(
+                "⚠️ Se detectó error no resuelto. Se suspende el uso del nuevo prompt."
+            )
+            # El sistema no aplica el siguiente prompt automáticamente
+            return
+
+    # Solo si no hubo errores previos no resueltos
+    ejecutar_automatizador()
 
     if codigo != 0 or "502" in salida:
         ejecutar_codex_entorno()


### PR DESCRIPTION
## Summary
- extend `supervisor_codex.py` with additional checks after the retry loop
- skip applying new prompts when critical errors remain unresolved
- run the automatizador only when errors are cleared

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_685c2575607883318566bc1b5c31ab7d