### PR TITLE
Fix tests by importing uuid4 and ensuring valid test users

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,14 +12,24 @@ from app.models import Usuario, Rol, Departamento, Requisicion
 def crear_usuario(username: str, rol_nombre: str, password: str = "test") -> Usuario:
     """Helper para crear usuarios durante las pruebas."""
     rol = Rol.query.filter_by(nombre=rol_nombre).first()
+    if not rol:
+        rol = Rol(nombre=rol_nombre, descripcion=f"Rol {rol_nombre}")
+        db.session.add(rol)
+        db.session.commit()
+
     departamento = Departamento.query.first()
+    if not departamento:
+        departamento = Departamento(nombre=f"Dept-{uuid4().hex[:6]}")
+        db.session.add(departamento)
+        db.session.commit()
+
     usuario = Usuario(
         username=username,
         cedula=f"V{uuid4().hex[:6]}",
         email=f"{username}_{uuid4().hex[:4]}@example.com",
         nombre_completo=username.capitalize(),
-        rol_id=rol.id if rol else None,
-        departamento_id=departamento.id if departamento else None,
+        rol_id=rol.id,
+        departamento_id=departamento.id,
         activo=True,
     )
     usuario.set_password(password)

--- a/tests/test_flujo_requisiciones.py
+++ b/tests/test_flujo_requisiciones.py
@@ -1,4 +1,5 @@
 import pytest
+from uuid import uuid4
 from unittest.mock import call
 from app import app as flask_app, db, crear_datos_iniciales
 from app.models import Usuario, Rol, Departamento, Requisicion
@@ -33,7 +34,16 @@ def crear_usuario(
 ):
     """Crea un usuario para pruebas garantizando unicidad en cédula y correo."""
     rol = Rol.query.filter_by(nombre=rol_nombre).first()
+    if not rol:
+        rol = Rol(nombre=rol_nombre, descripcion=f"Rol {rol_nombre}")
+        db.session.add(rol)
+        db.session.commit()
+
     departamento = Departamento.query.first()
+    if not departamento:
+        departamento = Departamento(nombre=f"Dept-{uuid4().hex[:6]}")
+        db.session.add(departamento)
+        db.session.commit()
 
     usuario = Usuario(
         username=username,
@@ -41,7 +51,7 @@ def crear_usuario(
         email=email or f"{username}_{uuid4().hex[:4]}@example.com",
         nombre_completo=username.capitalize(),
         rol_id=rol.id,
-        departamento_id=departamento.id if departamento else None,
+        departamento_id=departamento.id,
         activo=True,
     )
     usuario.set_password(password)


### PR DESCRIPTION
## Summary
- ensure test helper users always have valid required fields
- add missing uuid imports in requisition workflow tests

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_685c5f179f448331996b58636b93c133