### PR TITLE
Fix OpenAI chat completion call

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,11 +216,12 @@ async def run_agent(request: PromptRequest = Body(...)):
 
     try:
         if openai and openai_api_key:
-            respuesta = openai.ChatCompletion.create(
+            client = openai.OpenAI(api_key=openai_api_key)
+            respuesta = client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=[{"role": "user", "content": prompt}],
             )
-            mensaje = respuesta["choices"][0]["message"]["content"]
+            mensaje = respuesta.choices[0].message.content
         else:
             mensaje = f"Simulación de respuesta para: {prompt}"
         full_log.append(mensaje)


### PR DESCRIPTION
## Summary
- update to the new `openai` API for chat completions in `main.py`

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68633c1671548331bc82aff41e74f64b