### PR TITLE
Fix agent invocation

### DIFF
--- a/main.py
+++ b/main.py
@@ -267,7 +267,7 @@ async def run_agent(request: PromptRequest = Body(...)):
                 "OPENAI_API_KEY no configurada. Configúrala y reinicia la aplicación."
             )
         # Ejecutar el agente con el prompt del usuario
-        result = agent.run(prompt)
+        result = agent.invoke({"input": prompt})
         if not isinstance(result, str):
             result = str(result)
         agent_log.append(f"Respuesta final del agente: {result}")


### PR DESCRIPTION
## Summary
- use `invoke({"input": prompt})` instead of deprecated `run(prompt)`

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68634c4852a48331a5bde5ad8d7fae70