### PR TITLE
Fix OpenAI agent creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ try:
     from langchain.agents import create_openai_functions_agent, AgentExecutor
     from langchain.tools import tool
     from langgraph.graph import StateGraph, END
+    from langchain.agents.format_scratchpad.openai_tools import OpenAIFunctionsAgentPrompt
 except ImportError as e:
     raise ImportError("Necesitas instalar langchain y sus dependencias para ejecutar este agente.") 
 
@@ -238,7 +239,8 @@ else:
         openai_api_key=openai_api_key,
     )
     # Crear el agente base con las herramientas definidas
-    base_agent = create_openai_functions_agent(llm, tools)
+    prompt = OpenAIFunctionsAgentPrompt()
+    base_agent = create_openai_functions_agent(llm, tools, prompt)
     base_executor = AgentExecutor(agent=base_agent, tools=tools, verbose=False)
 
     class AgentState(TypedDict):


### PR DESCRIPTION
## Summary
- correct the `create_openai_functions_agent` call to provide an `OpenAIFunctionsAgentPrompt`

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68635030351883318369f47546560a1a