### PR TITLE
Fix prompt usage for LangChain >=0.2

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ try:
     from langchain.agents import create_openai_functions_agent, AgentExecutor
     from langchain.tools import tool
     from langgraph.graph import StateGraph, END
-    from langchain.agents.format_scratchpad.openai_tools import OpenAIFunctionsAgentPrompt
+    from langchain.agents.openai_functions_agent.prompt import FUNCTIONS_AGENT_PROMPT
 except ImportError as e:
     raise ImportError("Necesitas instalar langchain y sus dependencias para ejecutar este agente.") 
 
@@ -239,8 +239,7 @@ else:
         openai_api_key=openai_api_key,
     )
     # Crear el agente base con las herramientas definidas
-    prompt = OpenAIFunctionsAgentPrompt()
-    base_agent = create_openai_functions_agent(llm, tools, prompt)
+    base_agent = create_openai_functions_agent(llm, tools, FUNCTIONS_AGENT_PROMPT)
     base_executor = AgentExecutor(agent=base_agent, tools=tools, verbose=False)
 
     class AgentState(TypedDict):


### PR DESCRIPTION
## Summary
- update main agent prompt import path for modern LangChain
- adjust prompt usage when creating the agent

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_6863537cdfb48331afe80fc77daa16bd