### PR TITLE
Fix conditional edge call in workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,7 +282,10 @@ else:
     workflow.add_edge("interpret_prompt", "execute_tool")
     workflow.add_edge("execute_tool", "analyze_result")
     workflow.add_edge("analyze_result", "decide")
-    workflow.add_conditional_edges("decide", {"repeat": "interpret_prompt", "end": END})
+    workflow.add_conditional_edges("decide", {
+        "repeat": interpret_prompt,
+        "end": END
+    })
     workflow.set_entry_point("interpret_prompt")
     agent_executor = workflow.compile()
 


### PR DESCRIPTION
## Summary
- fix `add_conditional_edges` call in `main.py` to pass the function reference instead of a string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_6863588329888331bc612f91d798975d