### PR TITLE
Fix tool initialization for LangGraph agent

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,10 +20,10 @@ except ImportError as e:
     raise ImportError("Necesitas instalar langchain y sus dependencias para ejecutar este agente.") 
 
 # --- Definición de herramientas (Tools) para el agente ---
-# Se utiliza el decorador @tool de LangChain para permitir múltiples argumentos (OpenAI function-calling).
+# Las funciones se envuelven con el decorador ``tool`` al construir la lista
+# para permitir múltiples argumentos (OpenAI function-calling).
 agent_log = []  # Registro global de acciones del agente (se reinicia en cada petición)
 
-@tool
 def run_bash(cmd: str) -> str:
     """Ejecuta un comando Bash en el servidor y devuelve su salida."""
     global agent_log
@@ -42,7 +42,6 @@ def run_bash(cmd: str) -> str:
         agent_log.append(f"✖ Error en run_bash (inesperado): {error_msg}")
         return error_msg
 
-@tool
 def overwrite_file(path: str, content: str) -> str:
     """Sobrescribe el archivo especificado con el contenido proporcionado."""
     global agent_log
@@ -62,7 +61,6 @@ def overwrite_file(path: str, content: str) -> str:
         agent_log.append(f"✖ Error en overwrite_file: {error_msg}")
         return error_msg
 
-@tool
 def append_file(path: str, content: str) -> str:
     """Agrega el texto proporcionado al final del archivo especificado."""
     global agent_log
@@ -82,7 +80,6 @@ def append_file(path: str, content: str) -> str:
         agent_log.append(f"✖ Error en append_file: {error_msg}")
         return error_msg
 
-@tool
 def insert_line_after(path: str, line_to_find: str, new_line: str) -> str:
     """Inserta una nueva línea en el archivo dado, después de la primera aparición de 'line_to_find'."""
     global agent_log
@@ -120,7 +117,6 @@ def insert_line_after(path: str, line_to_find: str, new_line: str) -> str:
         agent_log.append(f"✖ Error en insert_line_after: {error_msg}")
         return error_msg
 
-@tool
 def restart_service(service_name: str) -> str:
     """Reinicia un servicio del sistema usando systemctl (requiere permisos adecuados)."""
     global agent_log
@@ -140,7 +136,6 @@ def restart_service(service_name: str) -> str:
         agent_log.append(f"✖ Error en restart_service: {error_msg}")
         return error_msg
 
-@tool
 def run_tests(test_path: str = "tests/") -> str:
     """Ejecuta PyTest en la ruta especificada (por defecto 'tests/') y devuelve la salida."""
     global agent_log
@@ -177,7 +172,6 @@ def test_example_failure():
         agent_log.append(f"✖ Error en run_tests: {error_msg}")
         return error_msg
 
-@tool
 def check_logs(log_path: str = "logs/app.log", num_lines: int = 100) -> str:
     """Lee las últimas 'num_lines' líneas del archivo de log especificado."""
     global agent_log
@@ -199,7 +193,6 @@ def check_logs(log_path: str = "logs/app.log", num_lines: int = 100) -> str:
         agent_log.append(f"✖ Error en check_logs: {error_msg}")
         return error_msg
 
-@tool
 def read_file(path: str) -> str:
     """Lee el contenido completo de un archivo de texto."""
     global agent_log
@@ -219,8 +212,16 @@ def read_file(path: str) -> str:
         return error_msg
 
 # Lista de herramientas disponibles para el agente
-tools = [run_bash, overwrite_file, append_file, insert_line_after,
-         restart_service, run_tests, check_logs, read_file]
+tools = [
+    tool(run_bash),
+    tool(overwrite_file),
+    tool(append_file),
+    tool(insert_line_after),
+    tool(restart_service),
+    tool(run_tests),
+    tool(check_logs),
+    tool(read_file),
+]
 
 # --- Configuración del modelo de lenguaje (LLM) y agente ---
 openai_api_key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
## Summary
- adjust comments around tools
- remove `@tool` decorators from helper functions
- wrap functions with `tool()` in the `tools` list

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68635cddbafc83319c08dc5199bb5f2b