### PR TITLE
Use explicit agent prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,9 @@ from langgraph.graph import StateGraph
 from langgraph.prebuilt import create_react_agent
 from langchain_core.runnables import RunnableLambda
 
+from langchain.agents.agent_toolkits.base import create_tool_calling_prompt
+from langchain_core.prompts import ChatPromptTemplate
+
 # Load environment variables if a .env file is present
 load_dotenv()
 
@@ -192,7 +195,12 @@ if openai_api_key:
         temperature=0,
         openai_api_key=openai_api_key,
     )
-    agent = create_react_agent(llm, tools)
+
+    # Crear prompt base para el agente con las herramientas
+    prompt = create_tool_calling_prompt(tools)
+
+    # Crear el agente con LLM, tools y prompt
+    agent = create_react_agent(llm=llm, tools=tools, prompt=prompt)
 
     class AgentState(TypedDict):
         input: str


### PR DESCRIPTION
## Summary
- build prompt using `create_tool_calling_prompt`
- pass prompt to `create_react_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68636b6c6ef88331bd347cd951d3a723