### PR TITLE
Fix create_react_agent call

### DIFF
--- a/main.py
+++ b/main.py
@@ -200,7 +200,7 @@ if openai_api_key:
         ("system", "Eres un asistente para desarrollo backend con Python. Usa las herramientas disponibles para ayudar al usuario."),
         ("human", "{input}")
     ])
-    agent = create_react_agent(llm, tools, prompt)
+    agent = create_react_agent(llm=llm, tools=tools, prompt=prompt)
 
     class AgentState(TypedDict):
         input: str


### PR DESCRIPTION
## Summary
- update `create_react_agent` call to use named arguments

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863e21de780833185d91d9604aa9c58