### PR TITLE
Fix RunnableLambda import in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from langgraph.graph import StateGraph, END
 from langgraph.prebuilt import create_react_agent
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough # Importar RunnablePassthrough
+from langchain_core.runnables import RunnableLambda
 
 # --- Definición manual de ToolInvocation para evitar ModuleNotFoundError ---
 # Si 'from langgraph.schema import ToolInvocation' falla constantemente,


### PR DESCRIPTION
## Summary
- add missing RunnableLambda import

## Testing
- `python run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_b_68642170eb78833199735138bef3d1e0